### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/src/Dtree.jl
+++ b/src/Dtree.jl
@@ -7,7 +7,7 @@ export DtreeScheduler, nnodes, nodeid, initwork, getwork, runtree, sync, cpu_pau
 const fan_out = 2048
 const drain_rate = 0.4
 
-const libdtree = joinpath(Pkg.dir("Dtree"), "deps", "Dtree",
+const libdtree = joinpath(dirname(dirname(@__FILE__)), "deps", "Dtree",
         "libdtree.$(Libdl.dlext)")
 
 enter_gc_safepoint() = ccall(:jl_gc_safe_enter, Int8, ())

--- a/test/dtreebench.jl
+++ b/test/dtreebench.jl
@@ -18,7 +18,7 @@ end
 
 const cpu_hz = 2.3e9
 
-const libdtree = joinpath(Pkg.dir("Dtree"), "deps", "Dtree",
+const libdtree = joinpath(dirname(dirname(@__FILE__)), "deps", "Dtree",
         "libdtree.$(Libdl.dlext)")
 
 @inline rdtsc() = ccall((:rdtsc, libdtree), Culonglong, ())


### PR DESCRIPTION
This allows installing the package elsewhere
